### PR TITLE
Add ability to disable native features at compile time.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ CC = $(CROSS_PREFIX)gcc
 AS = $(CROSS_PREFIX)gcc
 LD = $(CC)
 WARNINGS = -Wall -Wextra -Wstrict-prototypes -Wmissing-prototypes
-CFLAGS = -Os -fomit-frame-pointer $(WARNINGS)
+# Use -DDISABLE_NATFEATS=1 to disable NATFEATS at compile time.
+CFLAGS = -Os -fomit-frame-pointer $(WARNINGS) # -DDISABLE_NATFEATS=1
 LDFLAGS = -s
 
 ifeq ($(CROSS_PREFIX),)

--- a/pcmake.c
+++ b/pcmake.c
@@ -11,7 +11,6 @@
 #else
 #include <tos.h>
 #endif
-#include <mint/arch/nf_ops.h>
 #endif
 #include "getopt.h"
 #include "pcmake.h"

--- a/prj.c
+++ b/prj.c
@@ -11,7 +11,9 @@
 #else
 #include <tos.h>
 #endif
+#ifndef DISABLE_NATFEATS
 #include <mint/arch/nf_ops.h>
+#endif
 #define STRBSLASH(s) s
 #else
 #include <unistd.h>
@@ -824,6 +826,7 @@ static int docomp(PRJ *prj, MAKEOPTS *opts, filearg *ft)
 			fprintf(stdout, " %s", argv[i]);
 		fprintf(stdout, "\n");
 #if defined(__TOS__) || defined(__atarist__)
+#ifndef DISABLE_NATFEATS
 		if (opts->nfdebug)
 		{
 			nf_debug(argv[0]);
@@ -834,6 +837,7 @@ static int docomp(PRJ *prj, MAKEOPTS *opts, filearg *ft)
 			}
 			nf_debug("\n");
 		}
+#endif
 #endif
 	}
 	g_free(output_name);
@@ -1059,6 +1063,7 @@ static bool dold(PRJ *prj, MAKEOPTS *opts)
 				fprintf(stdout, " %s", argv[i]);
 			fprintf(stdout, "\n");
 #if defined(__TOS__) || defined(__atarist__)
+#ifndef DISABLE_NATFEATS
 			if (opts->nfdebug)
 			{
 				nf_debug(argv[0]);
@@ -1069,6 +1074,7 @@ static bool dold(PRJ *prj, MAKEOPTS *opts)
 				}
 				nf_debug("\n");
 			}
+#endif
 #endif
 		}
 		

--- a/utils.c
+++ b/utils.c
@@ -9,7 +9,9 @@
 #else
 #include <tos.h>
 #endif
+#ifndef DISABLE_NATFEATS
 #include <mint/arch/nf_ops.h>
+#endif
 #else
 #include <sys/stat.h>
 #include <unistd.h>
@@ -33,11 +35,13 @@ void errout_va(const char *format, va_list args)
 	vfprintf(stderr, format, args);
 	fputc('\n', stderr);
 #if defined(__TOS__) || defined(__atarist__)
+#ifndef DISABLE_NATFEATS
 	if (errout_nfdebug)
 	{
 		nf_debugvprintf(format, args);
 		nf_debug("\n");
 	}
+#endif
 #endif
 }
 


### PR DESCRIPTION
The cross-mint tool installation I'm using does not have the native feature (NATFEATS) include files. This commit allows native features support to be disabled at compile time using -DDISABLE_NATFEATS=1.

Thanks.